### PR TITLE
Fixes #305

### DIFF
--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/EntityFramework.SqlServerCompact.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/EntityFramework.SqlServerCompact.FunctionalTests.csproj
@@ -94,7 +94,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SqlServerCe, Version=3.5.1.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
@@ -158,10 +157,20 @@
     <Compile Include="InheritanceRelationshipsQuerySqlCeFixture.cs" />
     <Compile Include="InheritanceSqlCeFixture.cs" />
     <Compile Include="InheritanceSqlCeTest.cs" />
+    <Compile Include="Issue305Test.cs" />
     <Compile Include="MappingQuerySqlCeFixture.cs" />
     <Compile Include="MappingQuerySqlCeTest.cs" />
     <Compile Include="MigrationsSqlCeFixture.cs" />
     <Compile Include="MigrationsSqlCeTest.cs" />
+    <Compile Include="Migrations\20160215092248_Migration01.cs" />
+    <Compile Include="Migrations\20160215092248_Migration01.Designer.cs">
+      <DependentUpon>20160215092248_Migration01.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Migrations\20160215092329_Migration02.cs" />
+    <Compile Include="Migrations\20160215092329_Migration02.Designer.cs">
+      <DependentUpon>20160215092329_Migration02.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Migrations\TiffFilesContextModelSnapshot.cs" />
     <Compile Include="MonsterFixUpSqlCeTest.cs" />
     <Compile Include="NavigationTest.cs" />
     <Compile Include="NorthwindQuerySqlCeFixture.cs" />

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/Issue305Test.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/Issue305Test.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public class Issue305Test
+    {
+        [Fact]
+        public void Issue305_Test()
+        {
+            using (var db = new TiffFilesContext())
+            {
+                db.Database.EnsureDeleted();
+
+                db.Database.Migrate();
+            }
+        }
+
+        public class TiffFilesContext : DbContext
+        {
+            public DbSet<FileInfo> Files { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseSqlCe(@"Data Source=Issue305Database.sdf");
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<FileInfo>().Property(f => f.Path).IsRequired();
+            }
+        }
+
+        public class FileInfo
+        {
+            public int FileInfoId { get; set; }
+            public string Path { get; set; }
+            public String BlindedName { get; set; }
+            public bool ContainsSynapse { get; set; }
+            public int Quality { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/20160215092248_Migration01.Designer.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/20160215092248_Migration01.Designer.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ConsoleApplication3;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace ConsoleApplication3.Migrations
+{
+    [DbContext(typeof(Issue305Test.TiffFilesContext))]
+    [Migration("20160215092248_Migration01")]
+    partial class Migration01
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.0.0");
+
+            modelBuilder.Entity("ConsoleApplication3.FileInfo", b =>
+                {
+                    b.ToTable("FileInfo");
+
+                    b.Property<int>("FileInfoId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("BlindedName");
+
+                    b.Property<bool>("ContainsSynapse");
+
+                    b.Property<string>("Path")
+                        .IsRequired();
+
+                    b.HasKey("FileInfoId");
+                });
+        }
+    }
+}

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/20160215092248_Migration01.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/20160215092248_Migration01.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ConsoleApplication3.Migrations
+{
+    public partial class Migration01 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FileInfo",
+                columns: table => new
+                {
+                    FileInfoId = table.Column<int>(nullable: false)
+                        .Annotation("SqlCe:ValueGeneration", "True"),
+                    BlindedName = table.Column<string>(nullable: true),
+                    ContainsSynapse = table.Column<bool>(nullable: false),
+                    Path = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FileInfo", x => x.FileInfoId);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FileInfo");
+        }
+    }
+}

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/20160215092329_Migration02.Designer.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/20160215092329_Migration02.Designer.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ConsoleApplication3;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace ConsoleApplication3.Migrations
+{
+    [DbContext(typeof(Issue305Test.TiffFilesContext))]
+    [Migration("20160215092329_Migration02")]
+    partial class Migration02
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.0.0");
+
+            modelBuilder.Entity("ConsoleApplication3.FileInfo", b =>
+                {
+                    b.ToTable("FileInfo");
+
+                    b.Property<int>("FileInfoId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("BlindedName");
+
+                    b.Property<bool>("ContainsSynapse");
+
+                    b.Property<string>("Path")
+                        .IsRequired();
+
+                    b.Property<int>("Quality");
+
+                    b.HasKey("FileInfoId");
+                });
+        }
+    }
+}

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/20160215092329_Migration02.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/20160215092329_Migration02.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ConsoleApplication3.Migrations
+{
+    public partial class Migration02 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Quality",
+                table: "FileInfo",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Quality",
+                table: "FileInfo");
+        }
+    }
+}

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/TiffFilesContextModelSnapshot.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/Migrations/TiffFilesContextModelSnapshot.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace ConsoleApplication3.Migrations
+{
+    [DbContext(typeof(Issue305Test.TiffFilesContext))]
+    partial class TiffFilesContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.0.0");
+
+            modelBuilder.Entity("ConsoleApplication3.FileInfo", b =>
+                {
+                    b.ToTable("FileInfo");
+
+                    b.Property<int>("FileInfoId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("BlindedName");
+
+                    b.Property<bool>("ContainsSynapse");
+
+                    b.Property<string>("Path")
+                        .IsRequired();
+
+                    b.Property<int>("Quality");
+
+                    b.HasKey("FileInfoId");
+                });
+        }
+    }
+}

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/MigrationsSqlCeTest.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/MigrationsSqlCeTest.cs
@@ -22,15 +22,13 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
     [MigrationId] nvarchar(150) NOT NULL,
     [ProductVersion] nvarchar(32) NOT NULL,
     CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
-);
-
+)
 GO
 
 CREATE TABLE [Table1] (
     [Id] int NOT NULL,
     CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
-);
-
+)
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
@@ -38,8 +36,7 @@ VALUES ('00000000000001_Migration1', '7.0.0-test');
 
 GO
 
-sp_rename N'Table1', N'Table2';
-
+sp_rename N'Table1', N'Table2'
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
@@ -61,8 +58,7 @@ GO
             base.Can_generate_down_scripts();
 
             Assert.Equal(
-                @"sp_rename N'Table2', N'Table1';
-
+                @"sp_rename N'Table2', N'Table1'
 GO
 
 DELETE FROM [__EFMigrationsHistory]
@@ -70,8 +66,7 @@ WHERE [MigrationId] = '00000000000002_Migration2';
 
 GO
 
-DROP TABLE [Table1];
-
+DROP TABLE [Table1]
 GO
 
 DELETE FROM [__EFMigrationsHistory]

--- a/test/EntityFramework.SqlServerCompact.Tests/Migrations/SqlCeHistoryRepositoryTest.cs
+++ b/test/EntityFramework.SqlServerCompact.Tests/Migrations/SqlCeHistoryRepositoryTest.cs
@@ -29,7 +29,7 @@ namespace ErikEJ.Data.Entity.SqlServerCe.Tests.Migrations
                 "    [MigrationId] nvarchar(150) NOT NULL," + EOL +
                 "    [ProductVersion] nvarchar(32) NOT NULL," + EOL +
                 "    CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])" + EOL +
-                ");"+ EOL,
+                ")",
                 sql);
         }
 
@@ -43,7 +43,7 @@ namespace ErikEJ.Data.Entity.SqlServerCe.Tests.Migrations
                 "    [MigrationId] nvarchar(150) NOT NULL," + EOL +
                 "    [ProductVersion] nvarchar(32) NOT NULL," + EOL +
                 "    CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])" + EOL +
-                ");" + EOL,
+                ")",
                 sql);
         }
 

--- a/test/EntityFramework.SqlServerCompact.Tests/Migrations/SqlCeMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.SqlServerCompact.Tests/Migrations/SqlCeMigrationSqlGeneratorTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Migrations
             base.DropIndexOperation();
 
             Assert.Equal(
-                "DROP INDEX [IX_People_Name];" + EOL,
+                "DROP INDEX [IX_People_Name]",
                 Sql);
         }
 
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Migrations
                 });
 
             Assert.Equal(
-                "sp_rename N'People', N'Person';" + EOL,
+                "sp_rename N'People', N'Person'",
                 Sql);
         }
 
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Migrations
                 });
 
             Assert.Equal(
-                "ALTER TABLE [People] ADD [Id] int NOT NULL IDENTITY;" + EOL,
+                "ALTER TABLE [People] ADD [Id] int NOT NULL IDENTITY",
                 Sql);
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Migrations
                 });
 
             Assert.Equal(
-                "ALTER TABLE [People] ADD PRIMARY KEY ([Id]);" + EOL,
+                "ALTER TABLE [People] ADD PRIMARY KEY ([Id])",
                 Sql);
         }
 
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Migrations
             base.AlterColumnOperation();
 
             Assert.StartsWith(
-                "ALTER TABLE [People] ALTER COLUMN [LuckyNumber] DROP DEFAULT",
+                "ALTER TABLE [People] ALTER COLUMN [LuckyNumber] DROP DEFAULT" + EOL,
                 Sql);
         }
 
@@ -171,7 +171,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Migrations
                 });
 
             Assert.Equal(
-                "CREATE INDEX [IX_People_Name] ON [People] ([Name]);" + EOL,
+                "CREATE INDEX [IX_People_Name] ON [People] ([Name])",
                 Sql);
         }
     }

--- a/test/EntityFramework.SqlServerCompact35.FunctionalTests/EntityFramework.SqlServerCompact35.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServerCompact35.FunctionalTests/EntityFramework.SqlServerCompact35.FunctionalTests.csproj
@@ -94,7 +94,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">

--- a/test/EntityFramework.SqlServerCompact40.Design.FunctionalTest/EntityFramework.SqlServerCompact40.Design.FunctionalTest.csproj
+++ b/test/EntityFramework.SqlServerCompact40.Design.FunctionalTest/EntityFramework.SqlServerCompact40.Design.FunctionalTest.csproj
@@ -233,7 +233,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
- too many semicolons added during Migrations SQL generation,
reverting to overriding Generate