### PR TITLE
Demonstrate image column size does not equal written size.

### DIFF
--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/BasicEndToEndScenarioForNoIdentity.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/BasicEndToEndScenarioForNoIdentity.cs
@@ -15,10 +15,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 db.Database.EnsureDeleted();
                 db.Database.EnsureCreated();
                 var logo = File.ReadAllBytes("EFCore.png");
-                var logoSize = logo.Length;
                 db.Blogs.Add(new Blog { Id = 99, Url = "http://erikej.blogspot.com", Logo = logo });
                 db.SaveChanges();
+            }
 
+            using (var db = new BloggingContext())
+            {
+                var logo = File.ReadAllBytes("EFCore.png");
+                var logoSize = logo.Length;
 
                 var blogs = db.Blogs.ToList();
 


### PR DESCRIPTION
This change to the unit test should demonstrate that the image is NOT being read back the same as it was written. The resulting length is only 8000 bytes.

From issue: https://github.com/ErikEJ/EntityFramework.SqlServerCompact/issues/496